### PR TITLE
HUB-29 Migrate dropwizard-saml-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ Library for configuring a metadata healthcheck and providing a SAML Configuratio
 
 `./gradlew clean build`
 
+### Recreating the Jenkins build environment with docker
+
+To reproduce exactly what the Jenkins build server does, with docker, use the commands below to build the package and run the tests inside it. This is useful for re-creating and debugging build failures.
+
+docker run -it -v "$(pwd)":/app -w /app --rm build-container clean build test
+Connect to the container to poke around with it run
+
+'docker run --entrypoint="" build-container /bin/bash'
+
 ## Licence
 
 [MIT Licence](LICENCE)

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 apply plugin: 'java'
 
 repositories {
-    maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+    maven {
+        url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos'
+    }
 }
 
 ext {
@@ -13,20 +15,20 @@ version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 dependencies {
     compile "org.opensaml:opensaml-core:$opensaml_version",
-            "org.opensaml:opensaml-saml-impl:$opensaml_version",
-            'com.google.guava:guava:19.0',
-            'javax.validation:validation-api:1.1.0.Final',
-            'com.fasterxml.jackson.core:jackson-annotations:2.7.9',
-            'javax.inject:javax.inject:1',
-            "io.dropwizard:dropwizard-servlets:1.1.4",
-            'net.shibboleth.utilities:java-support:7.2.0',
-            "org.opensaml:opensaml-saml-api:$opensaml_version",
-            'io.dropwizard.metrics:metrics-healthchecks:3.2.2'
+        "org.opensaml:opensaml-saml-impl:$opensaml_version",
+        'com.google.guava:guava:19.0',
+        'javax.validation:validation-api:1.1.0.Final',
+        'com.fasterxml.jackson.core:jackson-annotations:2.7.9',
+        'javax.inject:javax.inject:1',
+        "io.dropwizard:dropwizard-servlets:1.1.4",
+        'net.shibboleth.utilities:java-support:7.2.0',
+        "org.opensaml:opensaml-saml-api:$opensaml_version",
+        'io.dropwizard.metrics:metrics-healthchecks:3.2.2'
 
     testCompile 'junit:junit:4.11',
-            'org.assertj:assertj-core:1.6.0',
-            'net.shibboleth.utilities:java-support:7.2.0',
-            "uk.gov.ida:saml-metadata-bindings-test:$opensaml_version-43"
+        'org.assertj:assertj-core:1.6.0',
+        'net.shibboleth.utilities:java-support:7.2.0',
+        "uk.gov.ida:saml-metadata-bindings-test:$opensaml_version-43"
 }
 
 apply plugin: 'maven-publish'
@@ -38,7 +40,12 @@ task sourceJar(type: Jar) {
 publishing {
     repositories {
         maven {
-            url "/srv/maven" // change to point to your repo, e.g. http://my.org/repo
+            credentials {
+                username "${System.env.ARTIUSER}"
+                password "${System.env.ARTIPASSWORD}"
+            }
+            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
+
         }
     }
     publications {

--- a/build.jenkins
+++ b/build.jenkins
@@ -1,16 +1,46 @@
 pipeline {
     agent none
     stages {
-       stage('Build') {
-           agent {
-         dockerfile {
-             additionalBuildArgs "--pull"
-         }
-     }
-           steps {
-               sh './gradlew build'
-           }
-       }
-   }
-}
+        stage('Build') {
+            agent {
+                dockerfile {
+                    additionalBuildArgs "--pull"
+                }
+            }
+            steps {
+                sh './gradlew build'
+            }
+        }
+        stage('Tag') {
+            when {
+                branch 'master'
+            }
+            agent any
+            environment {
+                ACCESS_TOKEN = credentials('verify-ci-build-scan-2017-12-20')
+            }
+            steps {
+                sh 'git config credential.username ${ACCESS_TOKEN_USR} && git config credential.helper "!echo password=\${ACCESS_TOKEN_PSW}; echo"'
+                sh 'git tag -a build_${BUILD_NUMBER} -m "jenkins2 tag build_${BUILD_NUMBER}" && GIT_ASKPASS=true git push origin build_${BUILD_NUMBER}'
+            }
+        }
+        stage('Publish') {
+            when {
+                branch 'master'
+            }
+            agent {
+                dockerfile {
+                    additionalBuildArgs "--pull"
+                }
+            }
+            environment {
+                ARTIUSER = "${env.ARTIFACTORYUSER}"
+                ARTIPASSWORD = "${env.ARTIFACTORYPASSWORD}"
+            }
+            steps {
+                sh './gradlew publish'
+            }
 
+        }
+    }
+}


### PR DESCRIPTION
Added Tag and Publish stages to the build.jenkins file and reformatted the build.gradle file for clarity. Have also added documentation detailing how to run the build locally, recreate the Jenkins environment with docker, and how to poke around with the docker environment.

Author: @callumknights